### PR TITLE
2026-03-monthly-report.org: style: disable underscore ⇒ sub processing

### DIFF
--- a/2026/2026-03-monthly-report.org
+++ b/2026/2026-03-monthly-report.org
@@ -1,6 +1,7 @@
 #+title:  Monthly Report for March 2026
 #+author: Philip Herron, Pierre-Emmanuel Patry and Arthur Cohen
 #+date:   2026-04-13
+#+options: ^:nil
 
 ** Overview
 


### PR DESCRIPTION
^:nil disables both superscript and subscript via ^ / _.

That causes entries with underscores to no longer be garbled.